### PR TITLE
SIANXSVC-705: Request size limits

### DIFF
--- a/cli/linter/schema.json
+++ b/cli/linter/schema.json
@@ -590,6 +590,9 @@
           "items": {
             "type": "string"
           }
+        },
+        "max_request_body_size": {
+          "type": "integer"
         }
       }
     },

--- a/config/config.go
+++ b/config/config.go
@@ -379,6 +379,9 @@ type HttpServerOptionsConfig struct {
 
 	// Custom SSL ciphers. See list of ciphers here https://tyk.io/docs/basic-config-and-security/security/tls-and-ssl/#specify-tls-cipher-suites-for-tyk-gateway--tyk-dashboard
 	Ciphers []string `json:"ssl_ciphers"`
+
+	// Maximum accepted request body size in byte.
+	MaxRequestBodySize int64 `json:"max_request_body_size"`
 }
 
 type AuthOverrideConf struct {

--- a/gateway/mw_request_size_limit.go
+++ b/gateway/mw_request_size_limit.go
@@ -11,7 +11,9 @@ import (
 	"github.com/TykTechnologies/tyk/headers"
 )
 
-// TransformMiddleware is a middleware that will apply a template to a request body to transform it's contents ready for an upstream API
+// RequestSizeLimitMiddleware is a middleware that will enforce a limit on the request body size. The request has
+// already been copied to memory when this middleware is called. Therefore, this middleware can't protect the gateway
+// itself from large requests.
 type RequestSizeLimitMiddleware struct {
 	BaseMiddleware
 }
@@ -22,7 +24,8 @@ func (t *RequestSizeLimitMiddleware) Name() string {
 
 func (t *RequestSizeLimitMiddleware) EnabledForSpec() bool {
 	for _, version := range t.Spec.VersionData.Versions {
-		if len(version.ExtendedPaths.SizeLimit) > 0 {
+		if len(version.ExtendedPaths.SizeLimit) > 0 ||
+			version.GlobalSizeLimit > 0 {
 			return true
 		}
 	}

--- a/gateway/proxy_muxer.go
+++ b/gateway/proxy_muxer.go
@@ -27,7 +27,8 @@ import (
 
 // handleWrapper's only purpose is to allow router to be dynamically replaced
 type handleWrapper struct {
-	router *mux.Router
+	router             *mux.Router
+	maxRequestBodySize int64
 }
 
 // h2cWrapper tracks handleWrapper for swapping w.router on reloads.
@@ -41,6 +42,18 @@ func (h *h2cWrapper) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *handleWrapper) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// limit request body size if configured
+	if h.maxRequestBodySize > 0 {
+		// if content length is set and already larger than the configured limit return a status 413
+		if r.ContentLength >= 0 && r.ContentLength > h.maxRequestBodySize {
+			http.HandlerFunc(requestEntityTooLarge).ServeHTTP(w, r)
+			return
+		}
+
+		// in case the content length is wrong or not set limit the reader itself
+		r.Body = http.MaxBytesReader(w, r.Body, h.maxRequestBodySize)
+	}
+
 	// make request body to be nopCloser and re-readable before serve it through chain of middlewares
 	nopCloseRequestBody(r)
 	if NewRelicApplication != nil {
@@ -403,7 +416,10 @@ func (m *proxyMux) serve(gw *Gateway) {
 				writeTimeout = time.Duration(conf.HttpServerOptions.WriteTimeout) * time.Second
 			}
 			var h http.Handler
-			h = &handleWrapper{p.router}
+			h = &handleWrapper{
+				router:             p.router,
+				maxRequestBodySize: conf.HttpServerOptions.MaxRequestBodySize,
+			}
 			// by default enabling h2c by wrapping handler in h2c. This ensures all features including tracing work
 			// in h2c services.
 			h2s := &http2.Server{}
@@ -492,4 +508,8 @@ func (m *proxyMux) generateListener(listenPort int, protocol string, gw *Gateway
 		return nil, err
 	}
 	return l, nil
+}
+
+func requestEntityTooLarge(w http.ResponseWriter, _ *http.Request) {
+	http.Error(w, "413 Request Entity Too Large", http.StatusRequestEntityTooLarge)
 }


### PR DESCRIPTION
- Adds a config option to set a server wide request size limit
- Fixes the api global setting in the request size limit middleware